### PR TITLE
Update js.controller / admin dependencies

### DIFF
--- a/JavaScript/io-package.json
+++ b/JavaScript/io-package.json
@@ -94,12 +94,12 @@
         "supportCustoms": true,
         "dependencies": [
             {
-                "js-controller": ">=3.3.22"
+                "js-controller": ">=4.0.24"
             }
         ],
         "globalDependencies": [
             {
-                "admin": ">=5.1.13"
+                "admin": ">=6.13.16"
             }
         ]
     },

--- a/JavaScriptReact/io-package.json
+++ b/JavaScriptReact/io-package.json
@@ -95,7 +95,7 @@
         "eraseOnUpload": true,
         "dependencies": [
             {
-                "js-controller": ">=3.3.22"
+                "js-controller": ">=4.0.24"
             }
         ],
         "globalDependencies": [

--- a/JavaScriptVIS/io-package.json
+++ b/JavaScriptVIS/io-package.json
@@ -97,13 +97,13 @@
         "supportCustoms": true,
         "dependencies": [
             {
-                "js-controller": ">=3.3.22"
+                "js-controller": ">=4.0.24"
             },
             "vis"
         ],
         "globalDependencies": [
             {
-                "admin": ">=5.1.13"
+                "admin": ">=6.13.16"
             }
         ]
     },

--- a/TypeScript/io-package.json
+++ b/TypeScript/io-package.json
@@ -94,12 +94,12 @@
 		"supportCustoms": true,
 		"dependencies": [
 			{
-				"js-controller": ">=3.3.22"
+				"js-controller": ">=4.0.24"
 			}
 		],
 		"globalDependencies": [
 			{
-				"admin": ">=5.1.13"
+				"admin": ">=6.13.16"
 			}
 		]
 	},

--- a/TypeScriptReact/io-package.json
+++ b/TypeScriptReact/io-package.json
@@ -95,7 +95,7 @@
 		"eraseOnUpload": true,
 		"dependencies": [
 			{
-				"js-controller": ">=3.3.22"
+				"js-controller": ">=4.0.24"
 			}
 		],
 		"globalDependencies": [

--- a/TypeScriptVIS/io-package.json
+++ b/TypeScriptVIS/io-package.json
@@ -97,13 +97,13 @@
 		"supportCustoms": true,
 		"dependencies": [
 			{
-				"js-controller": ">=3.3.22"
+				"js-controller": ">=4.0.24"
 			},
 			"vis"
 		],
 		"globalDependencies": [
 			{
-				"admin": ">=5.1.13"
+				"admin": ">=6.13.16"
 			}
 		]
 	},


### PR DESCRIPTION
@mcm1957 wrote in [this ticket](https://github.com/a-i-ks/ioBroker.volumio/issues/17) that these should be the minimum requirements for new adapters. I had used this template as a reference. We should therefore adjust the versions here.

> js-controller should be at least 4.0.24. 5.0.19 would be reommended for new (or almost new / renewed) adapters.
admin should be 6.13.16 as admin has several fixes for jsonConfig implemented at 6.x.x. So for new adapters 6.13.16 is recommended.